### PR TITLE
Add semaphores; spinlocks to allow for safe dual core operation

### DIFF
--- a/src/core/main.c
+++ b/src/core/main.c
@@ -3,6 +3,8 @@
 // FreeRTOS version macro (tskKERNEL_VERSION_NUMBER)
 #include "task.h"
 
+#include "semaphores.h"
+
 // Standard libraries
 #include "pico/stdio.h"
 #include "pico/stdlib.h"
@@ -58,6 +60,9 @@ int main(void)
 
     pvCreateUsbTasks();
     pvRegisterMcuTempTask();
+
+    // Create semaphores (mutex locks)
+    pvCreateSemaphores();
 
 #ifdef INCLUDES_FLASHLOADER
     pvRegisterFlashloaderTask();

--- a/src/core/main.cmake
+++ b/src/core/main.cmake
@@ -34,6 +34,7 @@ target_include_directories(${MAIN} PUBLIC
 target_sources(${MAIN} PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}/main.c
     ${CMAKE_CURRENT_LIST_DIR}/feature_set.c
+    ${CMAKE_CURRENT_LIST_DIR}/semaphores.c
     ${CMAKE_CURRENT_LIST_DIR}/usb/tasks.c
     ${CMAKE_CURRENT_LIST_DIR}/usb/vendor_request.c
     # TinyUSB functions not picked up unless we include it here (tud_vendor_control_xfer_cb)

--- a/src/core/rtos-config/FreeRTOSConfig.h
+++ b/src/core/rtos-config/FreeRTOSConfig.h
@@ -105,9 +105,10 @@
 */
 
 /* SMP port only */
-#define configNUM_CORES                         1 // not thread safe yet
+#define configNUM_CORES                         2 // not thread safe yet
 #define configTICK_CORE                         0
-#define configRUN_MULTIPLE_PRIORITIES           0
+#define configRUN_MULTIPLE_PRIORITIES           1
+#define configUSE_CORE_AFFINITY                 1
 
 /* RP2040 specific */
 #define configSUPPORT_PICO_SYNC_INTEROP         1

--- a/src/core/semaphores.c
+++ b/src/core/semaphores.c
@@ -1,0 +1,8 @@
+#include "semaphores.h"
+
+SemaphoreHandle_t xADCMutex;
+
+void pvCreateSemaphores(void)
+{
+    xADCMutex = xSemaphoreCreateMutex();
+}

--- a/src/core/semaphores.h
+++ b/src/core/semaphores.h
@@ -1,0 +1,11 @@
+#ifndef CORE_SEMAPHORES_H_
+#define CORE_SEMAPHORES_H_
+
+#include "FreeRTOS.h"
+#include "semphr.h"
+
+extern SemaphoreHandle_t xADCMutex;
+
+void pvCreateSemaphores(void);
+
+#endif /* CORE_SEMAPHORES_H_ */

--- a/src/core/usb/tasks.c
+++ b/src/core/usb/tasks.c
@@ -29,18 +29,22 @@ StaticTask_t cdc_taskdef;
 #endif
 
 // remember to start the scheduler using vTaskStartScheduler(); after calling this!
+
+// Create USB tasks.
+// Tie both tasks to core 0.
+// usbd and cdc must run on the same core or the cdc task will panic.
 void pvCreateUsbTasks(void)
 {
 #if configSUPPORT_STATIC_ALLOCATION
     // Create a task for tinyusb device stack
-    xTaskCreateStatic(usb_device_task, "usbd", USBD_STACK_SIZE, NULL, configMAX_PRIORITIES - 1, usb_device_stack, &usb_device_taskdef);
+    xTaskCreateStaticAffinitySet(usb_device_task, "usbd", USBD_STACK_SIZE, NULL, configMAX_PRIORITIES - 1, usb_device_stack, &usb_device_taskdef, 1 << 0);
 
     // Create CDC task
-    xTaskCreateStatic(cdc_task, "cdc", CDC_STACK_SZIE, NULL, configMAX_PRIORITIES - 2, cdc_stack, &cdc_taskdef);
+    xTaskCreateStaticAffinitySet(cdc_task, "cdc", CDC_STACK_SZIE, NULL, configMAX_PRIORITIES - 2, cdc_stack, &cdc_taskdef, 1 << 0);
 #else
     // Create tasks using dynamic memory allocation
-    xTaskCreate(usb_device_task, "usbd", USBD_STACK_SIZE, NULL, configMAX_PRIORITIES - 1, NULL);
-    xTaskCreate(cdc_task, "cdc", CDC_STACK_SZIE, NULL, configMAX_PRIORITIES - 2, NULL);
+    xTaskCreateAffinitySet(usb_device_task, "usbd", USBD_STACK_SIZE, NULL, configMAX_PRIORITIES - 1, 1 << 0, NULL);
+    xTaskCreateAffinitySet(cdc_task, "cdc", CDC_STACK_SZIE, NULL, configMAX_PRIORITIES - 2, 1 << 0, NULL);
 #endif
 }
 

--- a/src/flashloader/main.cmake
+++ b/src/flashloader/main.cmake
@@ -15,6 +15,7 @@ target_sources(${MAIN_FL_LINKED} PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}/crc32.c
     ${CMAKE_CURRENT_LIST_DIR}/main.c
     ${CMAKE_CURRENT_LIST_DIR}/dfu.c
+    ${CMAKE_CURRENT_LIST_DIR}/spinlock.c
     ${CMAKE_CURRENT_LIST_DIR}/ihex/record.c
     ${CMAKE_CURRENT_LIST_DIR}/ihex/util.c
     ${CMAKE_CURRENT_LIST_DIR}/ihex/process.c

--- a/src/flashloader/spinlock.c
+++ b/src/flashloader/spinlock.c
@@ -1,0 +1,47 @@
+// FreeRTOS core and task libraries
+#include "FreeRTOS.h"
+#include "task.h"
+
+#include "spinlock.h"
+
+#define SPINLOCK_STACK_SIZE configMINIMAL_STACK_SIZE
+
+// Define static tasks
+#if configSUPPORT_STATIC_ALLOCATION
+StackType_t spinlock_stack[USBD_STACK_SIZE];
+StaticTask_t spinlock_trigger_taskdef;
+#endif
+
+TaskHandle_t xHandle;
+
+// Spinlock function (eat up CPU time, an infinite loop)
+void __not_in_flash_func(spinlock)()
+{
+    while (true)
+    {
+    }
+}
+
+// Create the spinlock task
+void startSpinlock()
+{
+#if configSUPPORT_STATIC_ALLOCATION
+
+    // Create a STATIC task for the critical trigger
+    xHandle = xTaskCreateStaticAffinitySet(spinlock, "spinlock", SPINLOCK_STACK_SIZE, NULL, configMAX_PRIORITIES, spinlock_stack, &spinlock_trigger_taskdef, 1 << 1);
+
+#else /* configSUPPORT_STATIC_ALLOCATION */
+
+    // Create tasks using dynamic memory allocation
+    xTaskCreateAffinitySet(spinlock, "spinlock", SPINLOCK_STACK_SIZE, NULL, configMAX_PRIORITIES, 1 << 1, &xHandle);
+#endif
+}
+
+void stopSpinlock()
+{
+    if (xHandle != NULL)
+    {
+        vTaskDelete(xHandle);
+    }
+    // xHandle should now be null.
+}

--- a/src/flashloader/spinlock.h
+++ b/src/flashloader/spinlock.h
@@ -1,0 +1,8 @@
+#ifndef FLASHLOADER_SPINLOCK_H_
+#define FLASHLOADER_SPINLOCK_H_
+
+void startSpinlock();
+
+void stopSpinlock();
+
+#endif /* FLASHLOADER_SPINLOCK_H_ */


### PR DESCRIPTION
Added semaphores (ADC tasks)
Added spinlocks for safe dual core operation when flashing
  | USB runs on core 0, dfu blocks core 1 while flashing but is freed upon flashing finishing. This allows for buffered writes in the future - this is a rewrite of d4e3c5fd6a6b615e0cbb62afd206d940b15e4360 and 7bd0d5a6f6a758293549a1f4b334c2c73c00c6d5